### PR TITLE
Set default user-agent to <package-name>-<package-version>

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ SPEC_BASE_URL:=https://api.equinix.com/metal/v1/api-docs
 SPEC_ROOT_FILE:=openapi3.yaml
 SPEC_FETCHED_DIR=oas3.fetched
 
+
 fetch:
 		${FETCH_SPEC_COMMAND} ${SPEC_BASE_URL} ${SPEC_FETCHED_DIR} ${SPEC_ROOT_FILE}
 
@@ -46,6 +47,7 @@ OPENAPI_CONFIG:=oas3.config.json
 PACKAGE_NAME=equinix_metal
 PACKAGE_VERSION=0.0.1
 
+USER_AGENT=${PACKAGE_NAME}-${PACKAGE_VERSION}
 generate: clean patch-spec
 #	${OPENAPI_COMMAND} generate \
 		-i /local/${SPEC_PATCHED_FILE} \
@@ -53,6 +55,7 @@ generate: clean patch-spec
 		-o /local/${PACKAGE_NAME} \
 		--git-repo-id ${GIT_REPO} \
 		--git-user-id ${GIT_ORG}  \
+		--http-user-agent ${USER_AGENT} \
 	    --additional-properties=packageName=${PACKAGE_NAME},packageVersion=${PACKAGE_VERSION}
 	${OPENAPI_COMMAND} generate \
 		-i ${SPEC_PATCHED_FILE} \
@@ -60,4 +63,5 @@ generate: clean patch-spec
 		-o ${PACKAGE_NAME} \
 		--git-repo-id ${GIT_REPO} \
 		--git-user-id ${GIT_ORG}  \
+		--http-user-agent ${USER_AGENT} \
 	    --additional-properties=packageName=${PACKAGE_NAME},packageVersion=${PACKAGE_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ OPENAPI_CONFIG:=oas3.config.json
 PACKAGE_NAME=equinix_metal
 PACKAGE_VERSION=0.0.1
 
-USER_AGENT=${PACKAGE_NAME}-${PACKAGE_VERSION}
+USER_AGENT=${GIT_REPO}/${PACKAGE_VERSION}
 generate: clean patch-spec
 #	${OPENAPI_COMMAND} generate \
 		-i /local/${SPEC_PATCHED_FILE} \

--- a/equinix_metal/equinix_metal/api_client.py
+++ b/equinix_metal/equinix_metal/api_client.py
@@ -78,7 +78,7 @@ class ApiClient(object):
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'equinix_metal-0.0.1'
+        self.user_agent = 'metal-python/0.0.1'
         self.client_side_validation = configuration.client_side_validation
 
     def __enter__(self):

--- a/equinix_metal/equinix_metal/api_client.py
+++ b/equinix_metal/equinix_metal/api_client.py
@@ -78,7 +78,7 @@ class ApiClient(object):
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'OpenAPI-Generator/0.0.1/python'
+        self.user_agent = 'equinix_metal-0.0.1'
         self.client_side_validation = configuration.client_side_validation
 
     def __enter__(self):


### PR DESCRIPTION
This PR sets default user agent to $package-name-$package-version, for example equinix_metal-0.0.1. User can override it with the `user_agent()` setter of the Client object. 