### PR TITLE
Sort keys in fixed YAML spec

### DIFF
--- a/scripts/patch_metal_spec.py
+++ b/scripts/patch_metal_spec.py
@@ -214,7 +214,7 @@ fixedSpec['components']['schemas']['IPReservation']['properties']['assignments']
 
 with open(OUTFILE, 'w') as f:
     originalSpec = yaml.dump(
-        fixedSpec, f, sort_keys=False, default_flow_style=False)
+        fixedSpec, f, default_flow_style=False)
 
 
 print(INFILE, "was fixed into", OUTFILE)


### PR DESCRIPTION
sort keys in fixed spec, so that we can see better what changed in the upstream API spec