### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release Package to PyPI
+on:
+  push:
+    tags:
+    - 'v*.*.*'
+env:
+  PACKAGE_DIR: equinix_metal
+  DIST_DIR: equinix_metal/dist
+  PYTHON_VERSION: 3.8
+jobs:
+  build:
+    name: Build and publish package
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: Install dependencies
+      working-directory: ${{ env.PACKAGE_DIR }}
+      run: |
+        python -m pip install --upgrade build
+
+    - name: Build package
+      working-directory: ${{ env.PACKAGE_DIR }}
+      run: |
+        python -m build --sdist --wheel --outdir dist/ .
+
+    - name: Upload to PyPi
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        packages-dir: ${{ env.DIST_DIR }}
+
+


### PR DESCRIPTION
This PR adds release action for equinix-metal. It's triggered on tag push and it uploads the package build to PyPI.