### PR TITLE
Use openapi-generator-cli Docker image to generate code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,15 @@
+PACKAGE_VERSION=0.0.1
+
 SPEC_PATCHED_FILE=./metal_openapi.fixed.yaml
-OPENAPI_CODEGEN_SHA=sha256:925bc39fc00f8198cde01a2315afa815b37b2a44a9a43afed298adfc79da5770
+OPENAPI_CODEGEN_SHA=sha256:c07f666580053cc9f67a4adffad24c0ce6466c91d1ed1db8d05c39ba70f7ffdf
 OPENAPI_CODEGEN_IMAGE=openapitools/openapi-generator-cli@${OPENAPI_CODEGEN_SHA}
 CURRENT_UID := $(shell id -u)
 CURRENT_GID := $(shell id -g)
-
-# TODO: switch back to Docker once openapi-generator-cli fixes python-nextgen bugs
-#OPENAPI_COMMAND=docker run --rm -u ${CURRENT_UID}:${CURRENT_GID} -v $(CURDIR):/local ${OPENAPI_CODEGEN_IMAGE}
-OPENAPI_COMMAND=java -jar oag.jar
-
-.PHONY: all
-all: stitch-spec patch-spec clean generate fetch
-
+OPENAPI_COMMAND=docker run --rm -u ${CURRENT_UID}:${CURRENT_GID} -v $(CURDIR):/local ${OPENAPI_CODEGEN_IMAGE}
+GIT_REPO=metal-python
+GIT_ORG=equinix-labs
+OPENAPI_CONFIG:=oas3.config.json
+PACKAGE_NAME=equinix_metal
 STITCHED_DIR=oas3.stitched
 STITCHED_FILE=metal_openapi.yaml
 FETCH_SPEC_COMMAND=docker run --rm -v $(CURDIR):/workdir --entrypoint sh mikefarah/yq:4.30.8 scripts/download_spec.sh
@@ -18,21 +17,18 @@ SPEC_BASE_URL:=https://api.equinix.com/metal/v1/api-docs
 SPEC_ROOT_FILE:=openapi3.yaml
 SPEC_FETCHED_DIR=oas3.fetched
 
+.PHONY: all
+all: stitch-spec patch-spec clean generate fetch
 
 fetch:
 		${FETCH_SPEC_COMMAND} ${SPEC_BASE_URL} ${SPEC_FETCHED_DIR} ${SPEC_ROOT_FILE}
 
 stitch-spec: fetch
-#	${OPENAPI_COMMAND} generate \
+	${OPENAPI_COMMAND} generate \
 		-i /local/${SPEC_FETCHED_DIR}/${SPEC_ROOT_FILE} \
 		-g openapi-yaml \
 		-p skipOperationExample=true -p outputFile=${STITCHED_FILE} \
 		-o /local/${STITCHED_DIR}
-	${OPENAPI_COMMAND} generate \
-		-i ${SPEC_FETCHED_DIR}/${SPEC_ROOT_FILE} \
-		-g openapi-yaml \
-		-p skipOperationExample=true -p outputFile=${STITCHED_FILE} \
-		-o ${STITCHED_DIR}
 
 patch-spec: stitch-spec
 	scripts/patch_metal_spec.py ${STITCHED_DIR}/${STITCHED_FILE} ${SPEC_PATCHED_FILE}
@@ -41,26 +37,13 @@ clean:
 	rm -rf ${STITCHED_DIR}
 	rm -rf ${PACKAGE_NAME}
 
-GIT_REPO=metal-python
-GIT_ORG=equinix-labs
-OPENAPI_CONFIG:=oas3.config.json
-PACKAGE_NAME=equinix_metal
-PACKAGE_VERSION=0.0.1
 
 USER_AGENT=${GIT_REPO}/${PACKAGE_VERSION}
 generate: clean patch-spec
-#	${OPENAPI_COMMAND} generate \
+	${OPENAPI_COMMAND} generate \
 		-i /local/${SPEC_PATCHED_FILE} \
 		-g python-nextgen \
 		-o /local/${PACKAGE_NAME} \
-		--git-repo-id ${GIT_REPO} \
-		--git-user-id ${GIT_ORG}  \
-		--http-user-agent ${USER_AGENT} \
-	    --additional-properties=packageName=${PACKAGE_NAME},packageVersion=${PACKAGE_VERSION}
-	${OPENAPI_COMMAND} generate \
-		-i ${SPEC_PATCHED_FILE} \
-		-g python-nextgen \
-		-o ${PACKAGE_NAME} \
 		--git-repo-id ${GIT_REPO} \
 		--git-user-id ${GIT_ORG}  \
 		--http-user-agent ${USER_AGENT} \


### PR DESCRIPTION
Until now I have been using custom build of openapi-generator-cli because of some bugs [0,1,2] in upstream. Those bugs were fixed as of 20.03.2023. I tested the generated code and it works OK => We can use docker image containing the official build again. I fixed it to the hash of the latest master.

I also removed the oag.jar build of openapi-generator-cli, which have been in this repo for a couple of days, and grew the repo size by 25 MB. Sorry about that.

[0] https://github.com/OpenAPITools/openapi-generator/issues/14785
[1] https://github.com/OpenAPITools/openapi-generator/issues/14780
[2] https://github.com/OpenAPITools/openapi-generator/issues/14767