### PR TITLE
Trigger PyPI release on Github release, not on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Release Package to PyPI
 on:
-  push:
-    tags:
-    - 'v*.*.*'
+  release:
+    types: [published]
 env:
   PACKAGE_DIR: equinix_metal
   DIST_DIR: equinix_metal/dist


### PR DESCRIPTION
This PR changes Pypi release action to actual github release rather than tag push. Towards #22 