### PR TITLE
Mark paginated operations in spec patching script

### DIFF
--- a/scripts/patch_metal_spec.py
+++ b/scripts/patch_metal_spec.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import yaml
+import os
 from yaml.loader import FullLoader
 import copy
 import sys
@@ -76,6 +77,42 @@ fixedSpec['components']['schemas']['IPReservation']['properties']['assignments']
 # FIX 11. Make all Address parameters non-mandatory
 
 del fixedSpec['components']['schemas']['Address']['required']
+
+
+# Mark paginated operation with `x-equinix-metal-paginated-property`
+
+refkey = "$ref"
+
+
+for opPath, methods in fixedSpec['paths'].items():
+    if 'get' not in methods:
+        continue
+    getOp = methods['get']
+    if 'parameters' not in getOp:
+        continue
+    getOpParams = getOp['parameters']
+    for p in getOpParams:
+        if p['name'] != 'page':
+            continue
+        respSchemaPath = getOp['responses']['200']['content']['application/json']['schema'][refkey]
+        respSchemaName = os.path.basename(respSchemaPath)
+        oid = getOp['operationId']
+        respSchemaProperties = set(fixedSpec['components']['schemas'][respSchemaName]['properties'].keys())
+        if 'href' in respSchemaProperties:
+            respSchemaProperties.remove("href")
+        if 'meta' in respSchemaProperties:
+            respSchemaProperties.remove("meta")
+        else:
+            print("%s => %s doesn't have 'meta', and therefore no PageNum etc" % (oid, respSchemaName))
+            break
+        if len(respSchemaProperties) > 1:
+            print("%s => %s has 'page' but ambiguous response type with args %s" %
+                  (oid, respSchemaName, respSchemaProperties))
+            break
+        print("marking %s as paginated" % oid)
+        fixedSpec['paths'][opPath]['get']['x-equinix-metal-paginated-property'] = respSchemaProperties.pop()
+        break
+
 
 with open(OUTFILE, 'w') as f:
     originalSpec = yaml.dump(


### PR DESCRIPTION
This PR adds logic for generating listing functions capable of going through all the pages (think devices in a project, or events in a device).

It adds templates for the new code, docs, and code tests. The templates are fetched from oag v7.0.0, and then modified for the sake of the paginated listers.

It uses vendor extension property object in the form

     x-paginated:
        x-paginated-property: events
