### PR TITLE
ci: Add GH action for running integration tests via ansible-collection-equinix

### DIFF
--- a/.github/workflows/ansible-tests-pr.yml
+++ b/.github/workflows/ansible-tests-pr.yml
@@ -1,0 +1,73 @@
+on: 
+  pull_request_target:
+    paths:
+    - plugins/**
+    - tests/**
+    - Makefile
+    - requirements.txt
+    - requirements-dev.txt
+    - .github/**
+  workflow_dispatch:
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  authorize:
+    environment:
+      ${{ github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+
+  integration-test-pr:
+    needs: authorize
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .ansible/collections/ansible_collections/equinix/cloud
+    steps:
+      - name: checkout Ansible collection
+        uses: actions/checkout@v3
+        with:
+          name: equinix-labs/ansible-collection-equinix
+          path: .ansible/collections/ansible_collections/equinix/cloud
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - name: update packages
+        run: sudo apt-get update -y
+
+      - name: install make
+        run: sudo apt-get install -y build-essential
+
+      - name: setup python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+
+      - name: install dependencies
+        run: pip3 install -r requirements-dev.txt -r requirements.txt
+
+      - name: install collection
+        run: make install
+
+      - name: replace existing keys
+        run: rm -rf ~/.ansible/test && mkdir -p ~/.ansible/test && ssh-keygen -m PEM -q -t rsa -N '' -f ~/.ansible/test/id_rsa
+
+      - name: checkout Python SDK, this PR
+        uses: actions/checkout@v3
+        with:
+          path: /tmp/metal-python
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - name: install cloned Python SDK
+        run: python -m pip install /tmp/metal-python/equinix_metal
+
+      - name: run tests
+        run: make testall
+        env:
+          METAL_API_TOKEN: ${{ secrets.METAL_API_TOKEN }}
+

--- a/.github/workflows/ansible-tests-pr.yml
+++ b/.github/workflows/ansible-tests-pr.yml
@@ -1,11 +1,12 @@
 on: 
   pull_request_target:
     paths:
-    - plugins/**
-    - tests/**
-    - Makefile
-    - requirements.txt
-    - requirements-dev.txt
+    - config
+    - equinix_metal
+    - templates
+    - metal_openapi.fixed.yaml
+    - oas3.stitched
+    - oas3.fetched
     - .github/**
   workflow_dispatch:
 


### PR DESCRIPTION
This PR adds a GH action that will test metal-python PRs with integration tests from ansible-collectoin-equinix.

We clone the Ansible collection and then install metal-python version fetched from the PR. Then we run integration tests from Ansible collection.

This way we don't have to do an extra test suite for the generated Python SDK and we have some certainty that the relevant pieces of the generated code work.

It would be good to set User Agent for the Ansible calls. Right now it's not possible to do it over environment variables. We might need to implement settting UA over envvar in the Ansible collection.

For this to work, we also need METAL_API_TOKEN in secrets of this repo. Basically, the secrets and environments should be set just like in https://github.com/equinix-labs/ansible-collection-equinix.

@ctreatma what do you think?