### PR TITLE
fix: extending the validation rules for plans

### DIFF
--- a/equinix_metal/equinix_metal/models/plan_specs_drives_inner.py
+++ b/equinix_metal/equinix_metal/models/plan_specs_drives_inner.py
@@ -93,7 +93,7 @@ class PlanSpecsDrivesInner(BaseModel):
             "count": obj.get("count"),
             "href": obj.get("href"),
             "size": obj.get("size"),
-            "type": obj.get("type")
+            "type": obj.get("type").upper()
         })
         return _obj
 

--- a/equinix_metal/equinix_metal/models/plan_specs_drives_inner.py
+++ b/equinix_metal/equinix_metal/models/plan_specs_drives_inner.py
@@ -49,8 +49,8 @@ class PlanSpecsDrivesInner(BaseModel):
         if value is None:
             return value
 
-        if value not in ('HDD', 'SSD', 'NVME'):
-            raise ValueError("must be one of enum values ('HDD', 'SSD', 'NVME')")
+        if value not in ('HDD', 'SSD', 'NVME', 'NVMe'):
+            raise ValueError("must be one of enum values ('HDD', 'SSD', 'NVME', 'NVMe')")
         return value
 
     class Config:
@@ -93,7 +93,7 @@ class PlanSpecsDrivesInner(BaseModel):
             "count": obj.get("count"),
             "href": obj.get("href"),
             "size": obj.get("size"),
-            "type": obj.get("type").upper()
+            "type": obj.get("type")
         })
         return _obj
 

--- a/equinix_metal/equinix_metal/models/plan_specs_nics_inner.py
+++ b/equinix_metal/equinix_metal/models/plan_specs_nics_inner.py
@@ -37,8 +37,8 @@ class PlanSpecsNicsInner(BaseModel):
         if value is None:
             return value
 
-        if value not in ('1Gbps', '10Gbps', '25Gbps'):
-            raise ValueError("must be one of enum values ('1Gbps', '10Gbps', '25Gbps')")
+        if value not in ('1Gbps', '10Gbps', '25Gbps', '100Gbps'):
+            raise ValueError("must be one of enum values ('1Gbps', '10Gbps', '25Gbps', '100Gbps')")
         return value
 
     class Config:

--- a/scripts/patch_metal_spec.py
+++ b/scripts/patch_metal_spec.py
@@ -77,6 +77,12 @@ fixedSpec['components']['schemas']['IPReservation']['properties']['assignments']
 
 del fixedSpec['components']['schemas']['Address']['required']
 
+# FIX 12. Adding items for validation of enum PlanSpec
+
+fixedSpec['components']['schemas']['Plan_specs_drives_inner']['properties']['type']['enum'].append('NVMe')
+fixedSpec['components']['schemas']['Plan_specs_nics_inner']['properties']['type']['enum'].append('100Gbps')
+
+
 with open(OUTFILE, 'w') as f:
     originalSpec = yaml.dump(
         fixedSpec, f, default_flow_style=False)


### PR DESCRIPTION
When I list all the plans, there is a problem with inserting data into the objects, due to validation rules.

In one case, the 100Gbps value is missing in the enum.  
In the other, it returns 100mb instead of 100MB.

Maybe it's not specifically like this, I lost the cases in the history. I can execute it again if needed.