### PR TITLE
fix: remove 2 enums from Plan schema, they don't match the real API

### DIFF
--- a/equinix_metal/equinix_metal/models/plan_specs_drives_inner.py
+++ b/equinix_metal/equinix_metal/models/plan_specs_drives_inner.py
@@ -43,16 +43,6 @@ class PlanSpecsDrivesInner(BaseModel):
             raise ValueError("must be one of enum values ('boot', 'cache', 'storage')")
         return value
 
-    @validator('type')
-    def type_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in ('HDD', 'SSD', 'NVME'):
-            raise ValueError("must be one of enum values ('HDD', 'SSD', 'NVME')")
-        return value
-
     class Config:
         """Pydantic configuration"""
         allow_population_by_field_name = True

--- a/equinix_metal/equinix_metal/models/plan_specs_nics_inner.py
+++ b/equinix_metal/equinix_metal/models/plan_specs_nics_inner.py
@@ -20,7 +20,7 @@ import json
 
 
 from typing import Optional
-from pydantic import BaseModel, StrictInt, StrictStr, validator
+from pydantic import BaseModel, StrictInt, StrictStr
 
 class PlanSpecsNicsInner(BaseModel):
     """
@@ -30,16 +30,6 @@ class PlanSpecsNicsInner(BaseModel):
     href: Optional[StrictStr] = None
     type: Optional[StrictStr] = None
     __properties = ["count", "href", "type"]
-
-    @validator('type')
-    def type_validate_enum(cls, value):
-        """Validates the enum"""
-        if value is None:
-            return value
-
-        if value not in ('1Gbps', '10Gbps', '25Gbps'):
-            raise ValueError("must be one of enum values ('1Gbps', '10Gbps', '25Gbps')")
-        return value
 
     class Config:
         """Pydantic configuration"""

--- a/equinix_metal/test/test_device.py
+++ b/equinix_metal/test/test_device.py
@@ -213,7 +213,7 @@ class TestDevice(unittest.TestCase):
                                 count = 56, 
                                 href = '', 
                                 size = '3.84TB', 
-                                type = 'HDD', )
+                                type = '', )
                             ], 
                         features = equinix_metal.models.plan_specs_features.Plan_specs_features(
                             href = '', 
@@ -228,7 +228,7 @@ class TestDevice(unittest.TestCase):
                             equinix_metal.models.plan_specs_nics_inner.Plan_specs_nics_inner(
                                 count = 2, 
                                 href = '', 
-                                type = '1Gbps', )
+                                type = '', )
                             ], ), 
                     type = 'standard', ), 
                 project = None, 

--- a/equinix_metal/test/test_device_list.py
+++ b/equinix_metal/test/test_device_list.py
@@ -208,7 +208,7 @@ class TestDeviceList(unittest.TestCase):
                                         count = 56, 
                                         href = '', 
                                         size = '3.84TB', 
-                                        type = 'HDD', )
+                                        type = '', )
                                     ], 
                                 features = equinix_metal.models.plan_specs_features.Plan_specs_features(
                                     href = '', 
@@ -223,7 +223,7 @@ class TestDeviceList(unittest.TestCase):
                                     equinix_metal.models.plan_specs_nics_inner.Plan_specs_nics_inner(
                                         count = 2, 
                                         href = '', 
-                                        type = '1Gbps', )
+                                        type = '', )
                                     ], ), 
                             type = 'standard', ), 
                         project = null, 

--- a/equinix_metal/test/test_hardware_reservation.py
+++ b/equinix_metal/test/test_hardware_reservation.py
@@ -209,7 +209,7 @@ class TestHardwareReservation(unittest.TestCase):
                                     count = 56, 
                                     href = '', 
                                     size = '3.84TB', 
-                                    type = 'HDD', )
+                                    type = '', )
                                 ], 
                             features = equinix_metal.models.plan_specs_features.Plan_specs_features(
                                 href = '', 
@@ -224,7 +224,7 @@ class TestHardwareReservation(unittest.TestCase):
                                 equinix_metal.models.plan_specs_nics_inner.Plan_specs_nics_inner(
                                     count = 2, 
                                     href = '', 
-                                    type = '1Gbps', )
+                                    type = '', )
                                 ], ), 
                         type = 'standard', ), 
                     project = null, 
@@ -363,7 +363,7 @@ class TestHardwareReservation(unittest.TestCase):
                                 count = 56, 
                                 href = '', 
                                 size = '3.84TB', 
-                                type = 'HDD', )
+                                type = '', )
                             ], 
                         features = equinix_metal.models.plan_specs_features.Plan_specs_features(
                             href = '', 
@@ -378,7 +378,7 @@ class TestHardwareReservation(unittest.TestCase):
                             equinix_metal.models.plan_specs_nics_inner.Plan_specs_nics_inner(
                                 count = 2, 
                                 href = '', 
-                                type = '1Gbps', )
+                                type = '', )
                             ], ), 
                     type = 'standard', ), 
                 project = equinix_metal.models.project.Project(

--- a/equinix_metal/test/test_hardware_reservation_list.py
+++ b/equinix_metal/test/test_hardware_reservation_list.py
@@ -211,7 +211,7 @@ class TestHardwareReservationList(unittest.TestCase):
                                             count = 56, 
                                             href = '', 
                                             size = '3.84TB', 
-                                            type = 'HDD', )
+                                            type = '', )
                                         ], 
                                     features = equinix_metal.models.plan_specs_features.Plan_specs_features(
                                         href = '', 
@@ -226,7 +226,7 @@ class TestHardwareReservationList(unittest.TestCase):
                                         equinix_metal.models.plan_specs_nics_inner.Plan_specs_nics_inner(
                                             count = 2, 
                                             href = '', 
-                                            type = '1Gbps', )
+                                            type = '', )
                                         ], ), 
                                 type = 'standard', ), 
                             project = null, 

--- a/equinix_metal/test/test_invoice.py
+++ b/equinix_metal/test/test_invoice.py
@@ -95,7 +95,7 @@ class TestInvoice(unittest.TestCase):
                                         count = 56, 
                                         href = '', 
                                         size = '3.84TB', 
-                                        type = 'HDD', )
+                                        type = '', )
                                     ], 
                                 features = equinix_metal.models.plan_specs_features.Plan_specs_features(
                                     href = '', 
@@ -110,7 +110,7 @@ class TestInvoice(unittest.TestCase):
                                     equinix_metal.models.plan_specs_nics_inner.Plan_specs_nics_inner(
                                         count = 2, 
                                         href = '', 
-                                        type = '1Gbps', )
+                                        type = '', )
                                     ], ), 
                             type = 'standard', ), 
                         unit = '', 

--- a/equinix_metal/test/test_invoice_list.py
+++ b/equinix_metal/test/test_invoice_list.py
@@ -98,7 +98,7 @@ class TestInvoiceList(unittest.TestCase):
                                                 count = 56, 
                                                 href = '', 
                                                 size = '3.84TB', 
-                                                type = 'HDD', )
+                                                type = '', )
                                             ], 
                                         features = equinix_metal.models.plan_specs_features.Plan_specs_features(
                                             href = '', 
@@ -113,7 +113,7 @@ class TestInvoiceList(unittest.TestCase):
                                             equinix_metal.models.plan_specs_nics_inner.Plan_specs_nics_inner(
                                                 count = 2, 
                                                 href = '', 
-                                                type = '1Gbps', )
+                                                type = '', )
                                             ], ), 
                                     type = 'standard', ), 
                                 unit = '', 

--- a/equinix_metal/test/test_line_item.py
+++ b/equinix_metal/test/test_line_item.py
@@ -84,7 +84,7 @@ class TestLineItem(unittest.TestCase):
                                 count = 56, 
                                 href = '', 
                                 size = '3.84TB', 
-                                type = 'HDD', )
+                                type = '', )
                             ], 
                         features = equinix_metal.models.plan_specs_features.Plan_specs_features(
                             href = '', 
@@ -99,7 +99,7 @@ class TestLineItem(unittest.TestCase):
                             equinix_metal.models.plan_specs_nics_inner.Plan_specs_nics_inner(
                                 count = 2, 
                                 href = '', 
-                                type = '1Gbps', )
+                                type = '', )
                             ], ), 
                     type = 'standard', ), 
                 unit = '', 

--- a/equinix_metal/test/test_plan.py
+++ b/equinix_metal/test/test_plan.py
@@ -81,7 +81,7 @@ class TestPlan(unittest.TestCase):
                             count = 56, 
                             href = '', 
                             size = '3.84TB', 
-                            type = 'HDD', )
+                            type = '', )
                         ], 
                     features = equinix_metal.models.plan_specs_features.Plan_specs_features(
                         href = '', 
@@ -96,7 +96,7 @@ class TestPlan(unittest.TestCase):
                         equinix_metal.models.plan_specs_nics_inner.Plan_specs_nics_inner(
                             count = 2, 
                             href = '', 
-                            type = '1Gbps', )
+                            type = '', )
                         ], ), 
                 type = 'standard'
             )

--- a/equinix_metal/test/test_plan_list.py
+++ b/equinix_metal/test/test_plan_list.py
@@ -81,7 +81,7 @@ class TestPlanList(unittest.TestCase):
                                     count = 56, 
                                     href = '', 
                                     size = '3.84TB', 
-                                    type = 'HDD', )
+                                    type = '', )
                                 ], 
                             features = equinix_metal.models.plan_specs_features.Plan_specs_features(
                                 href = '', 
@@ -96,7 +96,7 @@ class TestPlanList(unittest.TestCase):
                                 equinix_metal.models.plan_specs_nics_inner.Plan_specs_nics_inner(
                                     count = 2, 
                                     href = '', 
-                                    type = '1Gbps', )
+                                    type = '', )
                                 ], ), 
                         type = 'standard', )
                     ]

--- a/equinix_metal/test/test_plan_specs.py
+++ b/equinix_metal/test/test_plan_specs.py
@@ -51,7 +51,7 @@ class TestPlanSpecs(unittest.TestCase):
                         count = 56, 
                         href = '', 
                         size = '3.84TB', 
-                        type = 'HDD', )
+                        type = '', )
                     ], 
                 features = equinix_metal.models.plan_specs_features.Plan_specs_features(
                     href = '', 
@@ -66,7 +66,7 @@ class TestPlanSpecs(unittest.TestCase):
                     equinix_metal.models.plan_specs_nics_inner.Plan_specs_nics_inner(
                         count = 2, 
                         href = '', 
-                        type = '1Gbps', )
+                        type = '', )
                     ]
             )
         else :

--- a/equinix_metal/test/test_plan_specs_drives_inner.py
+++ b/equinix_metal/test/test_plan_specs_drives_inner.py
@@ -43,7 +43,7 @@ class TestPlanSpecsDrivesInner(unittest.TestCase):
                 count = 56, 
                 href = '', 
                 size = '3.84TB', 
-                type = 'HDD'
+                type = ''
             )
         else :
             return PlanSpecsDrivesInner(

--- a/equinix_metal/test/test_plan_specs_nics_inner.py
+++ b/equinix_metal/test/test_plan_specs_nics_inner.py
@@ -41,7 +41,7 @@ class TestPlanSpecsNicsInner(unittest.TestCase):
             return PlanSpecsNicsInner(
                 count = 2, 
                 href = '', 
-                type = '1Gbps'
+                type = ''
             )
         else :
             return PlanSpecsNicsInner(

--- a/metal_openapi.fixed.yaml
+++ b/metal_openapi.fixed.yaml
@@ -3510,10 +3510,6 @@ components:
           example: 3.84TB
           type: string
         type:
-          enum:
-          - HDD
-          - SSD
-          - NVME
           type: string
       type: object
     Plan_specs_features:
@@ -3545,10 +3541,6 @@ components:
           format: uri
           type: string
         type:
-          enum:
-          - 1Gbps
-          - 10Gbps
-          - 25Gbps
           type: string
       type: object
     Port:

--- a/scripts/patch_metal_spec.py
+++ b/scripts/patch_metal_spec.py
@@ -78,6 +78,11 @@ fixedSpec['components']['schemas']['IPReservation']['properties']['assignments']
 
 del fixedSpec['components']['schemas']['Address']['required']
 
+# FIX 12. Remove enums from Plan schema - they don't match the real API
+# https://github.com/equinix-labs/metal-python/pull/63
+
+del fixedSpec['components']['schemas']['Plan_specs_drives_inner']['properties']['type']['enum']
+del fixedSpec['components']['schemas']['Plan_specs_nics_inner']['properties']['type']['enum']
 
 # Mark paginated operation with `x-equinix-metal-paginated-property`
 


### PR DESCRIPTION
This PR removes 2 enums from Plan subschemas, because the enumed values don't match the API.

Based on:
https://github.com/equinix/equinix-sdk-go/blob/main/spec/services/metalv1/patches/20230921-plan-drive-type.patch

fixes #63 

Most of the diff are tests, the relevant changes are two entries at the bottom.