### PR TITLE
fix: fix path to requirements.txt in gh action for intergration tests

### DIFF
--- a/.github/workflows/ansible-tests-pr.yml
+++ b/.github/workflows/ansible-tests-pr.yml
@@ -50,7 +50,7 @@ jobs:
           python-version: '3.8'
 
       - name: install dependencies
-        run: pip3 install -r requirements-dev.txt -r requirements.txt
+        run: pip3 install -r equinix-metal/requirements.txt
 
       - name: install collection
         run: make install


### PR DESCRIPTION
This PR fixes requirements path in Github action for integration tetsts.

https://github.com/equinix-labs/metal-python/actions/runs/7289232049/job/19863445294#step:6:16