### PR TITLE
fix: rename plans query param `categories` => `categories[]`

### DIFF
--- a/equinix_metal/equinix_metal/api/plans_api.py
+++ b/equinix_metal/equinix_metal/api/plans_api.py
@@ -168,8 +168,8 @@ class PlansApi(object):
         # process the query parameters
         _query_params = []
         if _params.get('categories') is not None:  # noqa: E501
-            _query_params.append(('categories', _params['categories']))
-            _collection_formats['categories'] = 'multi'
+            _query_params.append(('categories[]', _params['categories']))
+            _collection_formats['categories[]'] = 'multi'
 
         if _params.get('type') is not None:  # noqa: E501
             _query_params.append(('type', _params['type']))

--- a/metal_openapi.fixed.yaml
+++ b/metal_openapi.fixed.yaml
@@ -12187,7 +12187,7 @@ paths:
       parameters:
       - description: Filter plans by its category
         in: query
-        name: categories
+        name: categories[]
         schema:
           items:
             enum:

--- a/scripts/patch_metal_spec.py
+++ b/scripts/patch_metal_spec.py
@@ -84,6 +84,17 @@ del fixedSpec['components']['schemas']['Address']['required']
 del fixedSpec['components']['schemas']['Plan_specs_drives_inner']['properties']['type']['enum']
 del fixedSpec['components']['schemas']['Plan_specs_nics_inner']['properties']['type']['enum']
 
+# FIX 13. rename query attribute categories to "categories[]"
+
+plans_get_params = fixedSpec['paths']['/plans']['get']['parameters']
+
+for i, p in enumerate(plans_get_params):
+    if p['name'] == 'categories':
+        fixedSpec['paths']['/plans']['get']['parameters'][i]['name'] = "categories[]"
+        break
+
+
+
 # Mark paginated operation with `x-equinix-metal-paginated-property`
 
 refkey = "$ref"


### PR DESCRIPTION
This PR changes name of plans listing param `categories` to `categories[]`.

discovered by @ctreatma 
https://github.com/equinix-labs/metal-python/issues/69#issuecomment-1867924758

related to #69 

I wonder if we should this also for devices lookup. @ctreatma has this been fixed in metal-go?