### PR TITLE
fix: fixes in integration test GH action

### DIFF
--- a/.github/workflows/ansible-tests-pr.yml
+++ b/.github/workflows/ansible-tests-pr.yml
@@ -1,4 +1,4 @@
-on: 
+on:
   pull_request_target:
     paths:
     - config
@@ -27,17 +27,7 @@ jobs:
   integration-test-pr:
     needs: authorize
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: .ansible/collections/ansible_collections/equinix/cloud
     steps:
-      - name: checkout Ansible collection
-        uses: actions/checkout@v4
-        with:
-          name: equinix-labs/ansible-collection-equinix
-          path: .ansible/collections/ansible_collections/equinix/cloud
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
-
       - name: update packages
         run: sudo apt-get update -y
 
@@ -49,26 +39,33 @@ jobs:
         with:
           python-version: '3.8'
 
-      - name: install dependencies
-        run: pip3 install -r requirements-dev.txt -r requirements.txt
-
-      - name: install collection
-        run: make install
-
-      - name: replace existing keys
-        run: rm -rf ~/.ansible/test && mkdir -p ~/.ansible/test && ssh-keygen -m PEM -q -t rsa -N '' -f ~/.ansible/test/id_rsa
-
       - name: checkout Python SDK, this PR
         uses: actions/checkout@v4
         with:
-          path: /tmp/metal-python
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-      - name: install cloned Python SDK
-        run: python -m pip install /tmp/metal-python/equinix_metal
+      - name: checkout Ansible collection
+        uses: actions/checkout@v4
+        with:
+          repository: equinix-labs/ansible-collection-equinix
+          path: .ansible/collections/ansible_collections/equinix/cloud
+          ref: main
 
-      - name: run tests
+      - name: install dependencies of ansible collection
+        run: pip3 install -r requirements-dev.txt -r requirements.txt
+        working-directory: .ansible/collections/ansible_collections/equinix/cloud
+
+      - name: install cloned Python SDK
+        run: python3 -m pip install ./equinix_metal
+
+
+      - name: replace existing keys
+        run: rm -rf ~/.ansible/test && mkdir -p ~/.ansible/test && ssh-keygen -m PEM -q -t rsa -N '' -f ~/.ansible/test/id_rsa
+        working-directory: .ansible/collections/ansible_collections/equinix/cloud
+
+      - name: run tests in ansible collection directory
         run: make testall
+        working-directory: .ansible/collections/ansible_collections/equinix/cloud
         env:
           METAL_API_TOKEN: ${{ secrets.METAL_API_TOKEN }}
 


### PR DESCRIPTION
This PR fixes GH action for integration tests. 

The workflow should clone the ansible collection repo and install it. Right now it fails on pip install requirements because it's cloning this repo instead.