### PR TITLE
ci: update python in GHA for integration tests

### DIFF
--- a/.github/workflows/ansible-tests-pr.yml
+++ b/.github/workflows/ansible-tests-pr.yml
@@ -37,7 +37,7 @@ jobs:
       - name: setup python 3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: checkout Python SDK, this PR
         uses: actions/checkout@v4


### PR DESCRIPTION
I tried to sync this repo with latest API spec #82  and noticed that integration tests fail because we need Python 3.10 for ansible collection now https://github.com/equinix-labs/ansible-collection-equinix/pull/155

This PR updates Python in the integration tests GHA to 3.10. i will re-run the integration tests in #82 when we merge this.