### PR TITLE
chore: allow release workflow to push version change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        ssh-key: ${{ secrets.DEPLOY_KEY }}
 
     - name: Set up Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
This updates the release workflow to check out the code using a deploy key so that it will be able to commit the version number change back to main without needing a PR.  In the future it would be preferable to use a GitHub App token instead so that we can chain Actions workflows together instead of bypassing branch protection.